### PR TITLE
remove 1.9.3 test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 
 rvm:
-  - 1.9.3
   - 2.0.0
 
 bundler_args: --without development:production


### PR DESCRIPTION
@KitaitiMakoto 

hey i use only 2.0.0. do we need to test 1.9.3 anymore?
