### PR TITLE
Fix transition for chromium implementation

### DIFF
--- a/app/controllers/transition_controller.rb
+++ b/app/controllers/transition_controller.rb
@@ -1,6 +1,6 @@
 class TransitionController < ApplicationController
   def show
-    @uri = params[:uri]
+    @uri = CGI.unescape(params[:to])
 
     respond_to do |format|
       format.html

--- a/app/decorators/message_decorator.rb
+++ b/app/decorators/message_decorator.rb
@@ -24,7 +24,7 @@ class MessageDecorator < Draper::Decorator
       }
     else
       model.content.gsub URI.regexp(%w[http https ftp mailto]) do |uri|
-        h.link_to uri, h.transition_path(uri: h.url_encode(uri).gsub('.', '%2E'))
+        h.link_to uri, h.transition_path(to: uri)
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Iiirc::Application.routes.draw do
   delete '/signout'                 => 'sessions#destroy',       as: :signout
   get    '/auth/:provider/callback' => 'sessions#callback',      as: :callback
   get    '/signup'                  => 'users#new',              as: :signup
-  get    '/transition/:uri'         => 'transition#show',        as: :transition
+  get    '/transition'              => 'transition#show',        as: :transition
 
   scope '/api' do
     resources :snippets, controller: 'api/snippets', only: %w[show]

--- a/spec/decorators/message_decorator_spec.rb
+++ b/spec/decorators/message_decorator_spec.rb
@@ -26,7 +26,7 @@ describe MessageDecorator do
       end
 
       it 'marks URIs up as links to transition pages' do
-        expect(message.content).to eq('<a href="/transition/http%3A%2F%2Fiiirc%2Eorg%2F">http://iiirc.org/</a>')
+        expect(message.content).to eq('<a href="/transition?to=http%3A%2F%2Fiiirc.org%2F">http://iiirc.org/</a>')
       end
     end
 


### PR DESCRIPTION
Use query for URI of external pages instead of path info

Chromium/Chrome converts %2E to .(dot) when the link is clicked
and Rails consider following string as file extension.
