### PR TITLE
Use thread for PubsubhubbubNotifier#notify

### DIFF
--- a/app/models/pubsubhubbub_notifier.rb
+++ b/app/models/pubsubhubbub_notifier.rb
@@ -5,13 +5,15 @@ class PubsubhubbubNotifier
     attr_accessor :instances
 
     def notify
-      instances.each do |instance|
-        begin
-          instance.notify
-        rescue => e
-          Rails.logger.warn "[#{self}.#{__method__}]ERROR: #{e}"
-        end
-      end
+      instances.map {|instance|
+        Thread.new(instance) {
+          begin
+            instance.notify
+          rescue => e
+            Rails.logger.warn "[#{self}.#{__method__}]ERROR: #{e}"
+          end
+        }
+      }
     end
   end
 


### PR DESCRIPTION
If the method blocks, it keep user waiting until post is over.
It slows response time especially when posting to many hubs.
Joining to main thread is not needed because user and application
need not know whether posting is succeeded or not. We can see it by log.

The second step for #57 
