### PR TITLE
Enforce available locales

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -27,6 +27,7 @@ module Iiirc
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
+    config.i18n.enforce_available_locales = true
 
     # Configure the default encoding used in templates for Ruby 1.9.
     config.encoding = "utf-8"


### PR DESCRIPTION
In order to suppress a warning of I18n.
See also: http://blog.n-z.jp/blog/2013-12-04-rails-i18n-deprecated-warning.html
